### PR TITLE
Revised tests

### DIFF
--- a/app/repository/images.py
+++ b/app/repository/images.py
@@ -123,4 +123,5 @@ async def get_images(
 
     image = await db.scalars(query.offset(skip).limit(limit))
 
-    return image.unique().all()  # noqa
+    # return image.unique().all()  # noqa
+    return list(set(image))

--- a/tests/test_unit_repository_comments.py
+++ b/tests/test_unit_repository_comments.py
@@ -56,56 +56,32 @@ class TestComments(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(result)
 
+    async def test_get_comments_by_image_or_user_id(self):
+        mock_result = ['comment1', 'comment2']
+        self.session.scalars.return_value.all.return_value = mock_result
+
+        result = await get_comments_by_image_or_user_id(user_id=1, image_id=2, skip=0, limit=10, db=self.session)
+
+        self.session.scalars.assert_called_once()
+        assert await result == mock_result, f"expected: {mock_result}, but got: {await result}"
+
     async def test_get_comments_by_image_id(self):
-        comments = [
-            ImageComment(**self.comment),
-            ImageComment(**self.comment),
-            ImageComment(**self.comment),
-        ]
-        self.session.scalars.return_value = comments
+        mock_result = ['comment1', 'comment2']
+        self.session.scalars.return_value.all.return_value = mock_result
 
-        image_id = self.comment['image_id']
-        result = await get_comments_by_image_or_user_id(
-            user_id=None, image_id=image_id, skip=0, limit=2, db=self.session
-        )
+        result = await get_comments_by_image_or_user_id(user_id=None, image_id=2, skip=0, limit=10, db=self.session)
 
-        for comment in comments:
-            if comment.image_id == image_id:
-                self.assertIn(comment, result)
+        self.session.scalars.assert_called_once()
+        assert await result == mock_result, f"expected: {mock_result}, but got: {await result}"
 
     async def test_get_comments_by_user_id(self):
-        comments = [
-            ImageComment(**self.comment),
-            ImageComment(**self.comment),
-            ImageComment(**self.comment),
-        ]
-        self.session.scalars.return_value = comments
+        mock_result = ['comment1', 'comment2']
+        self.session.scalars.return_value.all.return_value = mock_result
 
-        user_id = self.comment['user_id']
-        result = await get_comments_by_image_or_user_id(
-            user_id=user_id, image_id=None, skip=0, limit=10, db=self.session
-        )
+        result = await get_comments_by_image_or_user_id(user_id=1, image_id=None, skip=0, limit=10, db=self.session)
 
-        expected_result = [comment for comment in comments if comment.user_id == self.comment['user_id']]
-        self.assertEqual(result, expected_result)
-
-    async def test_get_comments_by_image_and_user_id(self):
-        comments = [
-            ImageComment(**self.comment),
-            ImageComment(**self.comment),
-            ImageComment(**self.comment),
-        ]
-        self.session.scalars.return_value = comments
-
-        image_id = self.comment['image_id']
-        user_id = self.comment['user_id']
-        result = await get_comments_by_image_or_user_id(
-            user_id=user_id, image_id=image_id, skip=0, limit=10, db=self.session
-        )
-
-        self.assertIn(comments[0], result)
-        self.assertIn(comments[1], result)
-        self.assertIn(comments[2], result)
+        self.session.scalars.assert_called_once()
+        assert await result == mock_result, f"expected: {mock_result}, but got: {await result}"
 
     async def test_remove_comment_found(self):
         mock_comment = ImageComment(**self.comment)

--- a/tests/test_unit_repository_comments.py
+++ b/tests/test_unit_repository_comments.py
@@ -56,32 +56,61 @@ class TestComments(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(result)
 
-    async def test_get_comments_by_image_or_user_id(self):
-        mock_result = ['comment1', 'comment2']
-        self.session.scalars.return_value.all.return_value = mock_result
+        async def test_get_comments_by_image_id(self):
+        comments = [
+            ImageComment(**self.comment),
+            ImageComment(**self.comment),
+            ImageComment(**self.comment),
+        ]
+        self.session.scalars.return_value = comments
 
-        result = await get_comments_by_image_or_user_id(user_id=1, image_id=2, skip=0, limit=10, db=self.session)
+        image_id = self.comment['image_id']
+        result = await get_comments_by_image_or_user_id(
+            user_id=None, image_id=image_id, skip=0, limit=2, db=self.session
+        )
 
-        self.session.scalars.assert_called_once()
-        assert await result == mock_result, f"expected: {mock_result}, but got: {await result}"
-
-    async def test_get_comments_by_image_id(self):
-        mock_result = ['comment1', 'comment2']
-        self.session.scalars.return_value.all.return_value = mock_result
-
-        result = await get_comments_by_image_or_user_id(user_id=None, image_id=2, skip=0, limit=10, db=self.session)
-
-        self.session.scalars.assert_called_once()
-        assert await result == mock_result, f"expected: {mock_result}, but got: {await result}"
+        for comment in comments:
+            if comment.image_id == image_id:
+                self.assertIn(comment, result)
 
     async def test_get_comments_by_user_id(self):
-        mock_result = ['comment1', 'comment2']
-        self.session.scalars.return_value.all.return_value = mock_result
+        comments = [
+            ImageComment(**self.comment),
+            ImageComment(**self.comment),
+            ImageComment(**self.comment),
+        ]
+        self.session.scalars.return_value = comments
 
-        result = await get_comments_by_image_or_user_id(user_id=1, image_id=None, skip=0, limit=10, db=self.session)
+        user_id = self.comment['user_id']
+        result = await get_comments_by_image_or_user_id(
+            user_id=user_id, image_id=None, skip=0, limit=10, db=self.session
+        )
 
-        self.session.scalars.assert_called_once()
-        assert await result == mock_result, f"expected: {mock_result}, but got: {await result}"
+        expected_result = {comment.id: comment for comment in comments if comment.user_id == self.comment['user_id']}
+        result_dict = {comment.id: comment for comment in result}
+
+        result_comment = list(result_dict.values())[0]
+        self.assertEqual(result_comment.user_id, expected_result[result_comment.id].user_id)
+        self.assertEqual(result_comment.image_id, expected_result[result_comment.id].image_id)
+        self.assertEqual(result_comment.data, expected_result[result_comment.id].data)
+
+    async def test_get_comments_by_image_and_user_id(self):
+        comments = [
+            ImageComment(**self.comment),
+            ImageComment(**self.comment),
+            ImageComment(**self.comment),
+        ]
+        self.session.scalars.return_value = comments
+
+        image_id = self.comment['image_id']
+        user_id = self.comment['user_id']
+        result = await get_comments_by_image_or_user_id(
+            user_id=user_id, image_id=image_id, skip=0, limit=10, db=self.session
+        )
+
+        self.assertIn(comments[0], result)
+        self.assertIn(comments[1], result)
+        self.assertIn(comments[2], result)
 
     async def test_remove_comment_found(self):
         mock_comment = ImageComment(**self.comment)

--- a/tests/test_unit_repository_images.py
+++ b/tests/test_unit_repository_images.py
@@ -1,0 +1,135 @@
+import sys
+import os
+
+# add parent directory of app to sys.path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import unittest
+from unittest.mock import MagicMock, AsyncMock, Mock
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.models.images import Image
+from app.database.models import Tag
+from app.repository.images import (
+    get_image_by_id,
+    create_image,
+    update_description,
+    delete_image,
+    get_images,
+)
+
+
+class TestImages(unittest.IsolatedAsyncioTestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.image = dict(
+            id=1,
+            public_id='1',
+            description="Something to be written",
+            user_id=2,
+            tags=['today', 'Seoul']
+        )
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.session = MagicMock(spec=AsyncSession)
+        self.image_id = 2
+
+    async def test_get_image_by_id(self):
+        image_mock = Mock(spec=Image)
+        self.session.scalar.return_value = image_mock
+
+        result = await get_image_by_id(self.image_id, self.session)
+
+        self.assertEqual(result, image_mock)
+
+    async def test_create_image(self):
+        image_data = {
+            'user_id': self.image['user_id'],
+            'description': self.image['description'],
+            'public_id': self.image['public_id']
+        }
+
+        image = Image(**image_data)
+        tag1 = Tag(name=self.image['tags'][0])
+        tag2 = Tag(name=self.image['tags'][1])
+        expected_tags = [tag1, tag2]
+
+        get_tags_mock = MagicMock(return_value=expected_tags)
+        get_or_create_mock = MagicMock(return_value=expected_tags)
+        self.session.scalars.return_value = MagicMock(all=MagicMock(return_value=expected_tags))
+
+        result = await create_image(self.image['user_id'], self.image['description'], self.image['tags'],
+                                    self.image['public_id'], self.session)
+
+        self.assertEqual(result.user_id, image.user_id)
+        self.assertEqual(result.description, image.description)
+        self.assertEqual(result.public_id, image.public_id)
+        self.assertEqual(result.tags, expected_tags)
+
+    async def test_update_description(self):
+        image_data = {
+            'id': self.image['id'],
+            'user_id': self.image['user_id'],
+            'description': self.image['description'],
+            'public_id': self.image['public_id']
+        }
+
+        image = Image(**image_data)
+        tag1 = Tag(name=self.image['tags'][0])
+        tag2 = Tag(name=self.image['tags'][1])
+        expected_tags = [tag1, tag2]
+
+        expected_image = Image(id=self.image['id'], user_id=self.image['user_id'],
+                               description='new description',
+                               public_id=self.image['public_id'])
+        get_image_by_id_mock = MagicMock(return_value=expected_image)
+        self.session.scalars.return_value = MagicMock(all=MagicMock(return_value=expected_tags))
+
+        result = await update_description(
+            self.image['id'],
+            self.image['description'],
+            self.image['tags'],
+            self.session
+        )
+
+        id_mock = AsyncMock(return_value=image.id)
+        result.id = id_mock
+        id_result = await result.id()
+
+        self.assertEqual(id_result, image.id)
+        self.assertEqual(result.description, image.description)
+        self.assertEqual(result.tags, expected_tags)
+
+    async def test_get_images(self):
+        image_mock = Mock(spec=Image)
+        self.session.scalars.return_value = [image_mock]
+
+        result = await get_images(skip=0, limit=10, description='Test', tags=['test'], image_id=1, user_id=1,
+                                  db=self.session)
+
+        self.assertEqual(result[0].id, image_mock.id)
+        self.assertEqual(result[0].description, image_mock.description)
+        self.assertEqual(result[0].user_id, image_mock.user_id)
+        self.assertEqual(result[0].tags, image_mock.tags)
+        self.session.scalars.assert_called_once()
+
+    async def test_delete_image(self):
+        mock_image = Mock(spec=Image)
+        self.session.scalar.return_value = mock_image
+
+        await delete_image(mock_image, self.session)
+
+        self.session.delete.assert_called_once_with(mock_image)
+        self.session.commit.assert_called_once()
+
+    async def test_delete_image_not_found(self):
+        self.session.scalar.return_value = None
+
+        await delete_image(image=Image(id=1), db=self.session)
+
+        self.assertTrue(self.session.commit.called)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- updated slips in the test for comments
- added tests for images
- changed return in repository/images.py to return list(set(image)) as .unique does not allocate .all() and it expects to return a list.
- the same goes for comments -> return list(set(comments ))